### PR TITLE
Replace `html5test.com` with `html5test.co`

### DIFF
--- a/Gradle/Console/src/main/java/HelloConsole.java
+++ b/Gradle/Console/src/main/java/HelloConsole.java
@@ -37,7 +37,7 @@ public final class HelloConsole {
         Browser browser = engine.newBrowser();
 
         // Load a web page and wait until it is loaded completely.
-        browser.navigation().loadUrlAndWait("https://html5test.com/");
+        browser.navigation().loadUrlAndWait("https://html5test.co/");
 
         // Print HTML of the loaded web page.
         browser.mainFrame().ifPresent(frame -> System.out.println(frame.html()));

--- a/Gradle/JavaFX-11/README.md
+++ b/Gradle/JavaFX-11/README.md
@@ -30,6 +30,6 @@ Use the following command:
 ```
 
 It will build and start a JavaFX desktop application with JavaFX `BrowserView` inside that
-displays https://html5test.com as shown below:
+displays https://html5test.co as shown below:
 
 ![JavaFX BrowserView](https://jxbrowser-support.teamdev.com/img/articles/javafx-view.png)

--- a/Gradle/JavaFX-11/src/main/java/HelloFX11.java
+++ b/Gradle/JavaFX-11/src/main/java/HelloFX11.java
@@ -43,7 +43,7 @@ public final class HelloFX11 extends Application {
         Browser browser = engine.newBrowser();
 
         // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.com");
+        browser.navigation().loadUrl("https://html5test.co");
 
         // Create and embed JavaFX BrowserView component to display web content.
         BrowserView view = BrowserView.newInstance(browser);

--- a/Gradle/JavaFX/README.md
+++ b/Gradle/JavaFX/README.md
@@ -27,6 +27,6 @@ Use the following command:
 ./gradlew run -Djxbrowser.license.key=<your_license_key>
 ```
 
-It will build and start a JavaFX desktop application with JavaFX `BrowserView` inside that displays https://html5test.com as shown below:
+It will build and start a JavaFX desktop application with JavaFX `BrowserView` inside that displays https://html5test.co as shown below:
 
 ![JavaFX BrowserView](https://jxbrowser-support.teamdev.com/img/articles/javafx-view.png)

--- a/Gradle/JavaFX/src/main/java/HelloFX.java
+++ b/Gradle/JavaFX/src/main/java/HelloFX.java
@@ -43,7 +43,7 @@ public final class HelloFX extends Application {
         Browser browser = engine.newBrowser();
 
         // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.com");
+        browser.navigation().loadUrl("https://html5test.co");
 
         // Create and embed JavaFX BrowserView component to display web content.
         BrowserView view = BrowserView.newInstance(browser);

--- a/Gradle/SWT/README.md
+++ b/Gradle/SWT/README.md
@@ -23,6 +23,6 @@ Use the following command:
 ./gradlew run -Djxbrowser.license.key=<your_license_key>
 ```
 
-It will build and start an SWT desktop application with SWT `BrowserView` inside that displays https://html5test.com as shown below:
+It will build and start an SWT desktop application with SWT `BrowserView` inside that displays https://html5test.co as shown below:
 
 ![SWT BrowserView](https://jxbrowser-support.teamdev.com/img/articles/swt-view.png)

--- a/Gradle/SWT/src/main/java/HelloSWT.java
+++ b/Gradle/SWT/src/main/java/HelloSWT.java
@@ -42,7 +42,7 @@ public final class HelloSWT {
         Browser browser = engine.newBrowser();
 
         // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.com");
+        browser.navigation().loadUrl("https://html5test.co");
 
         Display display = new Display();
         Shell shell = new Shell(display);

--- a/Gradle/Swing/README.md
+++ b/Gradle/Swing/README.md
@@ -23,6 +23,6 @@ Use the following command:
 ./gradlew run -Djxbrowser.license.key=<your_license_key>
 ```
 
-It will build and start a Swing desktop application with Swing `BrowserView` inside that displays https://html5test.com as shown below:
+It will build and start a Swing desktop application with Swing `BrowserView` inside that displays https://html5test.co as shown below:
 
 ![Swing BrowserView](https://jxbrowser-support.teamdev.com/img/articles/awt-swing-view.png)

--- a/Gradle/Swing/src/main/java/HelloSwing.java
+++ b/Gradle/Swing/src/main/java/HelloSwing.java
@@ -58,7 +58,7 @@ public final class HelloSwing {
             frame.setVisible(true);
 
             // Load the required web page.
-            browser.navigation().loadUrl("https://html5test.com/");
+            browser.navigation().loadUrl("https://html5test.co/");
         });
     }
 }

--- a/Maven/Console/src/main/java/HelloConsole.java
+++ b/Maven/Console/src/main/java/HelloConsole.java
@@ -37,7 +37,7 @@ public final class HelloConsole {
         Browser browser = engine.newBrowser();
 
         // Load a web page and wait until it is loaded completely.
-        browser.navigation().loadUrlAndWait("https://html5test.com/");
+        browser.navigation().loadUrlAndWait("https://html5test.co/");
 
         // Print HTML of the loaded web page.
         browser.mainFrame().ifPresent(frame -> System.out.println(frame.html()));

--- a/Maven/JavaFX/src/main/java/HelloFX.java
+++ b/Maven/JavaFX/src/main/java/HelloFX.java
@@ -43,7 +43,7 @@ public final class HelloFX extends Application {
         Browser browser = engine.newBrowser();
 
         // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.com");
+        browser.navigation().loadUrl("https://html5test.co");
 
         // Create and embed JavaFX BrowserView component to display web content.
         BrowserView view = BrowserView.newInstance(browser);

--- a/Maven/SWT/src/main/java/HelloSWT.java
+++ b/Maven/SWT/src/main/java/HelloSWT.java
@@ -42,7 +42,7 @@ public final class HelloSWT {
         Browser browser = engine.newBrowser();
 
         // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.com");
+        browser.navigation().loadUrl("https://html5test.co");
 
         Display display = new Display();
         Shell shell = new Shell(display);

--- a/Maven/Swing/src/main/java/HelloSwing.java
+++ b/Maven/Swing/src/main/java/HelloSwing.java
@@ -58,7 +58,7 @@ public final class HelloSwing {
             frame.setVisible(true);
 
             // Load the required web page.
-            browser.navigation().loadUrl("https://html5test.com/");
+            browser.navigation().loadUrl("https://html5test.co/");
         });
     }
 }


### PR DESCRIPTION
This PR changes the not-working `html5test.com` link to `html5test.co` in examples and README.

Issue: https://github.com/TeamDev-IP/JxBrowser-Docs/issues/677