### PR TITLE
We don't use code owners practice anymore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# Order is important. The LAST matching pattern has the MOST precedence.
-# https://help.github.com/articles/about-codeowners
-
-# These owners will be the default owners for everything in the repo.
-# Unless a later match takes precedence, these people will be requested
-# for review when someone opens a pull request.
-* @vlad-lubenskyi @artem-trofimov


### PR DESCRIPTION
Code owner != product owner. We introduced the code owners to notify the product owners about every change in the repo. This can be done by subscribing to all the changes in the repo using the Watch functionality.