### PR TITLE
Update JxBrowser to v7.38.2

### DIFF
--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 jxbrowser {
-    version = "7.38.1"
+    version = "7.38.2"
 }
 
 dependencies {

--- a/Gradle/JavaFX-11/build.gradle.kts
+++ b/Gradle/JavaFX-11/build.gradle.kts
@@ -37,7 +37,7 @@ repositories {
 }
 
 jxbrowser {
-    version = "7.38.1"
+    version = "7.38.2"
 }
 
 dependencies {

--- a/Gradle/JavaFX/build.gradle.kts
+++ b/Gradle/JavaFX/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 jxbrowser {
-    version = "7.38.1"
+    version = "7.38.2"
 }
 
 dependencies {

--- a/Gradle/SWT/build.gradle.kts
+++ b/Gradle/SWT/build.gradle.kts
@@ -37,7 +37,7 @@ repositories {
 }
 
 jxbrowser {
-    version = "7.38.1"
+    version = "7.38.2"
 }
 
 dependencies {

--- a/Gradle/Swing/build.gradle.kts
+++ b/Gradle/Swing/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 jxbrowser {
-    version = "7.38.1"
+    version = "7.38.2"
 }
 
 dependencies {

--- a/Maven/Console/pom.xml
+++ b/Maven/Console/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jxbrowser.version>7.38.1</jxbrowser.version>
+        <jxbrowser.version>7.38.2</jxbrowser.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>

--- a/Maven/JavaFX/pom.xml
+++ b/Maven/JavaFX/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jxbrowser.version>7.38.1</jxbrowser.version>
+        <jxbrowser.version>7.38.2</jxbrowser.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>

--- a/Maven/SWT/pom.xml
+++ b/Maven/SWT/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jxbrowser.version>7.38.1</jxbrowser.version>
+        <jxbrowser.version>7.38.2</jxbrowser.version>
         <swt.version>4.3</swt.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>

--- a/Maven/Swing/pom.xml
+++ b/Maven/Swing/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jxbrowser.version>7.38.1</jxbrowser.version>
+        <jxbrowser.version>7.38.2</jxbrowser.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Bump JxBrowser version to 7.38.2

In this changeset, we: 

 * Update Gradle/Console/build.gradle.kts
 * Update Gradle/JavaFX-11/build.gradle.kts
 * Update Gradle/JavaFX/build.gradle.kts
 * Update Gradle/SWT/build.gradle.kts
 * Update Gradle/SWT/buildSrc/build.gradle.kts
 * Update Gradle/Swing/build.gradle.kts
 * Update Maven/Console/pom.xml
 * Update Maven/JavaFX/pom.xml
 * Update Maven/SWT/pom.xml
 * Update Maven/Swing/pom.xml

Issue: https://github.com/TeamDev-IP/JxBrowser-Docs/issues/1034