### PR TITLE
Add Kotlin examples

### DIFF
--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -21,7 +21,7 @@
 plugins {
     // Apply the java plugin to add support for Java
     java
-    
+
     // Apply the application plugin to add support for building a CLI application
     application
     kotlin("jvm") version "2.0.0"

--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -21,7 +21,7 @@
 plugins {
     // Apply the java plugin to add support for Java
     java
-
+    `kotlin-dsl`
     // Apply the application plugin to add support for building a CLI application
     application
     kotlin("jvm") version "2.0.0"
@@ -36,6 +36,9 @@ jxbrowser {
 dependencies {
     // Use JxBrowser cross-platform binaries
     implementation(jxbrowser.crossPlatform)
+
+    // Use JxBrowser Kotlin DSL
+    implementation(jxbrowser.kotlin)
 }
 
 repositories {

--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
     // Apply the application plugin to add support for building a CLI application
     application
-
+    kotlin("jvm") version "1.8.0"
     // Provides convenience methods for adding JxBrowser dependencies into a project
     id("com.teamdev.jxbrowser") version "1.2.1"
 }
@@ -36,6 +36,7 @@ jxbrowser {
 dependencies {
     // Use JxBrowser cross-platform binaries
     implementation(jxbrowser.crossPlatform)
+    implementation(kotlin("stdlib"))
 }
 
 application {

--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -21,7 +21,7 @@
 plugins {
     // Apply the java plugin to add support for Java
     java
-    `kotlin-dsl`
+    
     // Apply the application plugin to add support for building a CLI application
     application
     kotlin("jvm") version "2.0.0"

--- a/Gradle/Console/build.gradle.kts
+++ b/Gradle/Console/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
     // Apply the application plugin to add support for building a CLI application
     application
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
     // Provides convenience methods for adding JxBrowser dependencies into a project
     id("com.teamdev.jxbrowser") version "1.2.1"
 }
@@ -36,7 +36,10 @@ jxbrowser {
 dependencies {
     // Use JxBrowser cross-platform binaries
     implementation(jxbrowser.crossPlatform)
-    implementation(kotlin("stdlib"))
+}
+
+repositories {
+    mavenCentral()
 }
 
 application {

--- a/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
+++ b/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
@@ -1,0 +1,30 @@
+import com.teamdev.jxbrowser.engine.Engine
+import com.teamdev.jxbrowser.engine.EngineOptions
+import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+
+/**
+ * This example demonstrates how to load a web page, wait until it is loaded
+ * completely, and print its HTML without displaying any GUI.
+ */
+class HelloConsoleKt {
+
+    fun main() {
+        // Initialize Chromium.
+        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+                                   .licenseKey("your license key")
+                                   .build()
+        val engine = Engine.newInstance(options)
+
+        // Create a Browser instance.
+        val browser = engine.newBrowser()
+
+        // Load a web page and wait until it is loaded completely.
+        browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/")
+
+        // Print HTML of the loaded web page.
+        browser.mainFrame().ifPresent { frame -> println(frame.html()) }
+
+        // Shutdown Chromium and release allocated resources.
+        engine.close()
+    }
+}

--- a/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
+++ b/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
@@ -1,5 +1,6 @@
-import com.teamdev.jxbrowser.engine.Engine
-import com.teamdev.jxbrowser.engine.EngineOptions
+
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 
 /**
@@ -8,10 +9,9 @@ import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
  */
 fun main() {
     // Initialize Chromium.
-    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-        .licenseKey("your license key")
-        .build()
-    val engine = Engine.newInstance(options)
+    val engine = Engine(HARDWARE_ACCELERATED) {
+        license = JxBrowserLicense("your license key")
+    }
 
     // Create a Browser instance.
     val browser = engine.newBrowser()

--- a/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
+++ b/Gradle/Console/src/main/kotlin/HelloConsoleKt.kt
@@ -6,25 +6,22 @@ import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
  * This example demonstrates how to load a web page, wait until it is loaded
  * completely, and print its HTML without displaying any GUI.
  */
-class HelloConsoleKt {
+fun main() {
+    // Initialize Chromium.
+    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+        .licenseKey("your license key")
+        .build()
+    val engine = Engine.newInstance(options)
 
-    fun main() {
-        // Initialize Chromium.
-        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-                                   .licenseKey("your license key")
-                                   .build()
-        val engine = Engine.newInstance(options)
+    // Create a Browser instance.
+    val browser = engine.newBrowser()
 
-        // Create a Browser instance.
-        val browser = engine.newBrowser()
+    // Load a web page and wait until it is loaded completely.
+    browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/")
 
-        // Load a web page and wait until it is loaded completely.
-        browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/")
+    // Print HTML of the loaded web page.
+    browser.mainFrame().ifPresent { frame -> println(frame.html()) }
 
-        // Print HTML of the loaded web page.
-        browser.mainFrame().ifPresent { frame -> println(frame.html()) }
-
-        // Shutdown Chromium and release allocated resources.
-        engine.close()
-    }
+    // Shutdown Chromium and release allocated resources.
+    engine.close()
 }

--- a/Gradle/JavaFX/build.gradle.kts
+++ b/Gradle/JavaFX/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
 
     // Use JxBrowser JavaFX GUI toolkit
     implementation(jxbrowser.javafx)
+
+    // Use JxBrowser Kotlin DSL
+    implementation(jxbrowser.kotlin)
 }
 
 javafx {

--- a/Gradle/JavaFX/build.gradle.kts
+++ b/Gradle/JavaFX/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
+    kotlin("jvm") version "1.8.0"
+
     // Apply the application plugin to add support for building a CLI application
     application
 

--- a/Gradle/JavaFX/build.gradle.kts
+++ b/Gradle/JavaFX/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 
     // Apply the application plugin to add support for building a CLI application
     application

--- a/Gradle/JavaFX/src/main/kotlin/HelloFXKt.kt
+++ b/Gradle/JavaFX/src/main/kotlin/HelloFXKt.kt
@@ -1,5 +1,7 @@
-import com.teamdev.jxbrowser.engine.Engine
-import com.teamdev.jxbrowser.engine.EngineOptions
+
+
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 import com.teamdev.jxbrowser.view.javafx.BrowserView
 import javafx.application.Application
@@ -15,10 +17,9 @@ import javafx.stage.Stage
 class HelloFxKt : Application() {
     override fun start(primaryStage: Stage) {
         // Initialize Chromium.
-        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-            .licenseKey("your license key")
-            .build()
-        val engine = Engine.newInstance(options)
+        val engine = Engine(HARDWARE_ACCELERATED) {
+            license = JxBrowserLicense("your license key")
+        }
 
         // Create a Browser instance.
         val browser = engine.newBrowser()
@@ -36,7 +37,6 @@ class HelloFxKt : Application() {
 
         // Shutdown Chromium and release allocated resources.
         primaryStage.setOnCloseRequest { engine.close() }
-
     }
 
     fun run() {

--- a/Gradle/JavaFX/src/main/kotlin/HelloFxKt.kt
+++ b/Gradle/JavaFX/src/main/kotlin/HelloFxKt.kt
@@ -1,0 +1,41 @@
+import com.teamdev.jxbrowser.engine.Engine
+import com.teamdev.jxbrowser.engine.EngineOptions
+import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+import com.teamdev.jxbrowser.view.javafx.BrowserView
+import javafx.application.Application
+import javafx.scene.Scene
+import javafx.scene.layout.BorderPane
+import javafx.stage.Stage
+
+/**
+ * This example demonstrates how to initialize Chromium, create a browser instance
+ * (equivalent of the Chromium tab), embed a JavaFX BrowserView component into JavaFX
+ * scene to display content of the loaded web page, load the required web page.
+ */
+class HelloFxKt : Application() {
+    override fun start(primaryStage: Stage) {
+        // Initialize Chromium.
+        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+            .licenseKey("your license key")
+            .build()
+        val engine = Engine.newInstance(options)
+
+        // Create a Browser instance.
+        val browser = engine.newBrowser()
+
+        // Load the required web page.
+        browser.navigation().loadUrl("https://html5test.teamdev.com")
+
+        // Create and embed JavaFX BrowserView component to display web content.
+        val view = BrowserView.newInstance(browser)
+
+        val scene = Scene(BorderPane(view), 1280.0, 800.0)
+        primaryStage.title = "JxBrowser JavaFX"
+        primaryStage.scene = scene
+        primaryStage.show()
+
+        // Shutdown Chromium and release allocated resources.
+        primaryStage.setOnCloseRequest { engine.close() }
+
+    }
+}

--- a/Gradle/JavaFX/src/main/kotlin/HelloFxKt.kt
+++ b/Gradle/JavaFX/src/main/kotlin/HelloFxKt.kt
@@ -38,4 +38,12 @@ class HelloFxKt : Application() {
         primaryStage.setOnCloseRequest { engine.close() }
 
     }
+
+    fun run() {
+        launch()
+    }
+}
+
+fun main() {
+    HelloFxKt().run()
 }

--- a/Gradle/SWT/build.gradle.kts
+++ b/Gradle/SWT/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation(jxbrowser.swt)
 
     implementation(Swt.toolkitDependency)
+
+    // Use JxBrowser Kotlin DSL
+    implementation(jxbrowser.kotlin)
 }
 
 Swt.configurePlatformDependency(project)

--- a/Gradle/SWT/build.gradle.kts
+++ b/Gradle/SWT/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 
     // Apply the application plugin to add support for building a CLI application
     application

--- a/Gradle/SWT/build.gradle.kts
+++ b/Gradle/SWT/build.gradle.kts
@@ -25,6 +25,8 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
+    kotlin("jvm") version "1.8.0"
+
     // Apply the application plugin to add support for building a CLI application
     application
 
@@ -69,4 +71,3 @@ tasks.withType<JavaExec> {
     // the command line to the JavaExec task.
     systemProperties(System.getProperties().mapKeys { it.key as String })
 }
-

--- a/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
+++ b/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
@@ -1,4 +1,3 @@
-
 import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.engine.EngineOptions
 import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
@@ -12,40 +11,38 @@ import org.eclipse.swt.widgets.Shell
  * (equivalent of the Chromium tab), embed a Swing BrowserView component into Java Swing
  * frame to display content of the loaded web page, load the required web page.
  */
-class HelloSwtKt {
-    fun main() {
-        // Initialize Chromium.
-        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-            .licenseKey("your license key")
-            .build()
-        val engine = Engine.newInstance(options)
+fun main() {
+    // Initialize Chromium.
+    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+        .licenseKey("your license key")
+        .build()
+    val engine = Engine.newInstance(options)
 
-        // Create a Browser instance.
-        val browser = engine.newBrowser()
+    // Create a Browser instance.
+    val browser = engine.newBrowser()
 
-        // Load the required web page.
-        browser.navigation().loadUrl("https://html5test.teamdev.com")
+    // Load the required web page.
+    browser.navigation().loadUrl("https://html5test.teamdev.com")
 
-        val display = Display()
-        val shell = Shell(display)
-        shell.text = "JxBrowser SWT"
-        shell.layout = FillLayout()
+    val display = Display()
+    val shell = Shell(display)
+    shell.text = "JxBrowser SWT"
+    shell.layout = FillLayout()
 
-        // Create and embed SWT BrowserView widget to display web content.
-        val view = BrowserView.newInstance(shell, browser)
-        view.setSize(1280, 800)
+    // Create and embed SWT BrowserView widget to display web content.
+    val view = BrowserView.newInstance(shell, browser)
+    view.setSize(1280, 800)
 
-        shell.pack()
-        shell.open()
+    shell.pack()
+    shell.open()
 
-        while (!shell.isDisposed) {
-            if (!display.readAndDispatch()) {
-                display.sleep()
-            }
+    while (!shell.isDisposed) {
+        if (!display.readAndDispatch()) {
+            display.sleep()
         }
-        // Shutdown Chromium and release allocated resources.
-        engine.close()
-
-        display.dispose()
     }
+    // Shutdown Chromium and release allocated resources.
+    engine.close()
+
+    display.dispose()
 }

--- a/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
+++ b/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
@@ -1,5 +1,6 @@
-import com.teamdev.jxbrowser.engine.Engine
-import com.teamdev.jxbrowser.engine.EngineOptions
+
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 import com.teamdev.jxbrowser.view.swt.BrowserView
 import org.eclipse.swt.layout.FillLayout
@@ -13,10 +14,9 @@ import org.eclipse.swt.widgets.Shell
  */
 fun main() {
     // Initialize Chromium.
-    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-        .licenseKey("your license key")
-        .build()
-    val engine = Engine.newInstance(options)
+    val engine = Engine(HARDWARE_ACCELERATED) {
+        license = JxBrowserLicense("your license key")
+    }
 
     // Create a Browser instance.
     val browser = engine.newBrowser()

--- a/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
+++ b/Gradle/SWT/src/main/kotlin/HelloSwtKt.kt
@@ -1,0 +1,51 @@
+
+import com.teamdev.jxbrowser.engine.Engine
+import com.teamdev.jxbrowser.engine.EngineOptions
+import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+import com.teamdev.jxbrowser.view.swt.BrowserView
+import org.eclipse.swt.layout.FillLayout
+import org.eclipse.swt.widgets.Display
+import org.eclipse.swt.widgets.Shell
+
+/**
+ * This example demonstrates how to initialize Chromium, create a browser instance
+ * (equivalent of the Chromium tab), embed a Swing BrowserView component into Java Swing
+ * frame to display content of the loaded web page, load the required web page.
+ */
+class HelloSwtKt {
+    fun main() {
+        // Initialize Chromium.
+        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+            .licenseKey("your license key")
+            .build()
+        val engine = Engine.newInstance(options)
+
+        // Create a Browser instance.
+        val browser = engine.newBrowser()
+
+        // Load the required web page.
+        browser.navigation().loadUrl("https://html5test.teamdev.com")
+
+        val display = Display()
+        val shell = Shell(display)
+        shell.text = "JxBrowser SWT"
+        shell.layout = FillLayout()
+
+        // Create and embed SWT BrowserView widget to display web content.
+        val view = BrowserView.newInstance(shell, browser)
+        view.setSize(1280, 800)
+
+        shell.pack()
+        shell.open()
+
+        while (!shell.isDisposed) {
+            if (!display.readAndDispatch()) {
+                display.sleep()
+            }
+        }
+        // Shutdown Chromium and release allocated resources.
+        engine.close()
+
+        display.dispose()
+    }
+}

--- a/Gradle/Swing/build.gradle.kts
+++ b/Gradle/Swing/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
+    kotlin("jvm") version "1.8.0"
+
     // Apply the application plugin to add support for building a CLI application
     application
 

--- a/Gradle/Swing/build.gradle.kts
+++ b/Gradle/Swing/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     // Apply the java plugin to add support for Java
     java
 
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "2.0.0"
 
     // Apply the application plugin to add support for building a CLI application
     application
@@ -33,6 +33,10 @@ plugins {
 
 jxbrowser {
     version = "8.0.0"
+}
+
+repositories {
+    mavenCentral()
 }
 
 dependencies {

--- a/Gradle/Swing/build.gradle.kts
+++ b/Gradle/Swing/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
 
     // Use JxBrowser Swing GUI toolkit
     implementation(jxbrowser.swing)
+
+    // Use JxBrowser Kotlin DSL
+    implementation(jxbrowser.kotlin)
 }
 
 application {

--- a/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
+++ b/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
@@ -12,33 +12,31 @@ import javax.swing.SwingUtilities
  * (equivalent of the Chromium tab), embed a Swing BrowserView component into Java Swing
  * frame to display content of the loaded web page, load the required web page.
  */
-class HelloSwingKt {
-    fun main() {
-        // Initialize Chromium.
-        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-            .licenseKey("your license key")
-            .build()
-        val engine = Engine.newInstance(options)
+fun main() {
+    // Initialize Chromium.
+    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+        .licenseKey("your license key")
+        .build()
+    val engine = Engine.newInstance(options)
 
-        // Create a Browser instance.
-        val browser = engine.newBrowser()
+    // Create a Browser instance.
+    val browser = engine.newBrowser()
 
-        SwingUtilities.invokeLater {
-            val frame = JFrame("JxBrowser AWT/Swing")
-            frame.addWindowListener(object : WindowAdapter() {
-                override fun windowClosing(e: WindowEvent) {
-                    // Shutdown Chromium and release allocated resources.
-                    engine.close()
-                }
-            })
-            // Create and embed Swing BrowserView component to display web content.
-            frame.add(BrowserView.newInstance(browser))
-            frame.setSize(1280, 800)
-            frame.setLocationRelativeTo(null)
-            frame.isVisible = true
+    SwingUtilities.invokeLater {
+        val frame = JFrame("JxBrowser AWT/Swing")
+        frame.addWindowListener(object : WindowAdapter() {
+            override fun windowClosing(e: WindowEvent) {
+                // Shutdown Chromium and release allocated resources.
+                engine.close()
+            }
+        })
+        // Create and embed Swing BrowserView component to display web content.
+        frame.add(BrowserView.newInstance(browser))
+        frame.setSize(1280, 800)
+        frame.setLocationRelativeTo(null)
+        frame.isVisible = true
 
-            // Load the required web page.
-            browser.navigation().loadUrl("https://html5test.teamdev.com/")
-        }
+        // Load the required web page.
+        browser.navigation().loadUrl("https://html5test.teamdev.com/")
     }
 }

--- a/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
+++ b/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
@@ -1,0 +1,44 @@
+import com.teamdev.jxbrowser.engine.Engine
+import com.teamdev.jxbrowser.engine.EngineOptions
+import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
+import com.teamdev.jxbrowser.view.swing.BrowserView
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+
+/**
+ * This example demonstrates how to initialize Chromium, create a browser instance
+ * (equivalent of the Chromium tab), embed a Swing BrowserView component into Java Swing
+ * frame to display content of the loaded web page, load the required web page.
+ */
+class HelloSwingKt {
+    fun main() {
+        // Initialize Chromium.
+        val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+            .licenseKey("your license key")
+            .build()
+        val engine = Engine.newInstance(options)
+
+        // Create a Browser instance.
+        val browser = engine.newBrowser()
+
+        SwingUtilities.invokeLater {
+            val frame = JFrame("JxBrowser AWT/Swing")
+            frame.addWindowListener(object : WindowAdapter() {
+                override fun windowClosing(e: WindowEvent) {
+                    // Shutdown Chromium and release allocated resources.
+                    engine.close()
+                }
+            })
+            // Create and embed Swing BrowserView component to display web content.
+            frame.add(BrowserView.newInstance(browser))
+            frame.setSize(1280, 800)
+            frame.setLocationRelativeTo(null)
+            frame.isVisible = true
+
+            // Load the required web page.
+            browser.navigation().loadUrl("https://html5test.teamdev.com/")
+        }
+    }
+}

--- a/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
+++ b/Gradle/Swing/src/main/kotlin/HelloSwingKt.kt
@@ -1,5 +1,5 @@
-import com.teamdev.jxbrowser.engine.Engine
-import com.teamdev.jxbrowser.engine.EngineOptions
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.JxBrowserLicense
 import com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED
 import com.teamdev.jxbrowser.view.swing.BrowserView
 import java.awt.event.WindowAdapter
@@ -14,27 +14,27 @@ import javax.swing.SwingUtilities
  */
 fun main() {
     // Initialize Chromium.
-    val options = EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-        .licenseKey("your license key")
-        .build()
-    val engine = Engine.newInstance(options)
+    val engine = Engine(HARDWARE_ACCELERATED) {
+        license = JxBrowserLicense("your license key")
+    }
 
     // Create a Browser instance.
     val browser = engine.newBrowser()
 
     SwingUtilities.invokeLater {
-        val frame = JFrame("JxBrowser AWT/Swing")
-        frame.addWindowListener(object : WindowAdapter() {
-            override fun windowClosing(e: WindowEvent) {
-                // Shutdown Chromium and release allocated resources.
-                engine.close()
-            }
-        })
-        // Create and embed Swing BrowserView component to display web content.
-        frame.add(BrowserView.newInstance(browser))
-        frame.setSize(1280, 800)
-        frame.setLocationRelativeTo(null)
-        frame.isVisible = true
+        JFrame("JxBrowser AWT/Swing").apply {
+            // Shutdown Chromium and release allocated resources when the frame closes.
+            addWindowListener(object : WindowAdapter() {
+                override fun windowClosing(e: WindowEvent) {
+                    engine.close()
+                }
+            })
+            // Create and embed Swing BrowserView component to display web content.
+            add(BrowserView.newInstance(browser))
+            setSize(1280, 800)
+            setLocationRelativeTo(null)
+            isVisible = true
+        }
 
         // Load the required web page.
         browser.navigation().loadUrl("https://html5test.teamdev.com/")


### PR DESCRIPTION
In this changeset, we added idiomatic Kotlin examples, leveraging Kotlin DSL to enhance their appeal for Kotlin users.

Issue: TeamDev-IP/JxBrowser/issues/4083