### PR TITLE
Add instructions for using JxBrowser license key in the Quick Start projects

### DIFF
--- a/Gradle/Compose/README.md
+++ b/Gradle/Compose/README.md
@@ -1,6 +1,6 @@
-# JxBrowser in Swing Gradle Project
+# JxBrowser in Compose Gradle Project
 
-This example demonstrates how to configure a Gradle project with JxBrowser to embed a Swing `BrowserView` widget into a Swing desktop application to display web pages.
+This example demonstrates how to configure a Gradle project with JxBrowser to embed a Compose `BrowserView` widget into a Compose desktop application to display web pages.
 
 ## Download the Project
 
@@ -8,14 +8,14 @@ Clone this repository using the following command:
 
  ```bash
  git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
- cd JxBrowser-QuickStart/Gradle/Swing
+ cd JxBrowser-QuickStart/Gradle/Compose
  ```
 
 ## Get License
 
 Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
 
-## Run the Swing Application
+## Run the Compose Application
 
 Use the following command:
 
@@ -23,6 +23,5 @@ Use the following command:
 ./gradlew run -Djxbrowser.license.key=<your_license_key>
 ```
 
-It will build and start a Swing desktop application with Swing `BrowserView` inside that displays https://html5test.teamdev.com as shown below:
-
-![Swing BrowserView](https://jxbrowser-support.teamdev.com/img/articles/awt-swing-view.png)
+It will build and start a Compose desktop application with Swing `BrowserView` inside that displays https://html5test.teamdev.com as shown below: 
+![Compose BrowserView](compose-browser-view.png)

--- a/Gradle/Compose/README.md
+++ b/Gradle/Compose/README.md
@@ -24,4 +24,5 @@ Use the following command:
 ```
 
 It will build and start a Compose desktop application with Swing `BrowserView` inside that displays https://html5test.teamdev.com as shown below: 
+
 ![Compose BrowserView](compose-browser-view.png)

--- a/Gradle/Console/README.md
+++ b/Gradle/Console/README.md
@@ -1,0 +1,26 @@
+# JxBrowser in Console Gradle Project
+
+This example demonstrates how to configure a Gradle project with JxBrowser to use it in a console application.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
+ cd JxBrowser-QuickStart/Gradle/Console
+ ```
+
+## Get License
+
+Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the Console Application
+
+Use the following command:
+
+```bash
+./gradlew run -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start a console application with HTML of https://html5test.teamdev.com printed into console. 

--- a/Gradle/Console/README.md
+++ b/Gradle/Console/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to configure a Gradle project with JxBrowser to use it in a console application.
 
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
 ## Download the Project
 
 Clone this repository using the following command:

--- a/Gradle/SWT/README.md
+++ b/Gradle/SWT/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to configure a Gradle project with JxBrowser to embed an SWT `BrowserView` widget into an SWT desktop application to display web pages. 
 
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
 ## Download the Project
 
 Clone this repository using the following command:

--- a/Gradle/Swing/README.md
+++ b/Gradle/Swing/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to configure a Gradle project with JxBrowser to embed a Swing `BrowserView` widget into a Swing desktop application to display web pages.
 
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
 ## Download the Project
 
 Clone this repository using the following command:

--- a/Maven/Console/README.md
+++ b/Maven/Console/README.md
@@ -1,0 +1,26 @@
+# JxBrowser in Console Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to use it in a console application.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
+ cd JxBrowser-QuickStart/Gradle/Console
+ ```
+
+## Get License
+
+Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the Console Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start a console application with HTML of https://html5test.teamdev.com printed into console. 

--- a/Maven/Console/README.md
+++ b/Maven/Console/README.md
@@ -2,13 +2,17 @@
 
 This example demonstrates how to configure a Maven project with JxBrowser to use it in a console application.
 
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
 ## Download the Project
 
 Clone this repository using the following command:
 
  ```bash
  git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
- cd JxBrowser-QuickStart/Gradle/Console
+ cd JxBrowser-QuickStart/Maven/Console
  ```
 
 ## Get License

--- a/Maven/Console/pom.xml
+++ b/Maven/Console/pom.xml
@@ -12,6 +12,7 @@
         <jxbrowser.version>8.1.0</jxbrowser.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloConsole</exec.mainClass>
     </properties>
 
     <repositories>

--- a/Maven/JavaFX/README.md
+++ b/Maven/JavaFX/README.md
@@ -1,0 +1,35 @@
+# JxBrowser in JavaFX Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to embed a JavaFX `BrowserView` widget into
+a JavaFX desktop application to display web pages.
+
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
+ cd JxBrowser-QuickStart/Gradle/JavaFX
+ ```
+
+## Get License
+
+Download a free 30-day trial key by sending a request via
+the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the JavaFX Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start a JavaFX desktop application with JavaFX `BrowserView` inside that
+displays https://html5test.teamdev.com as shown below:
+
+![JavaFX BrowserView](https://jxbrowser-support.teamdev.com/img/articles/javafx-view.png)

--- a/Maven/JavaFX/README.md
+++ b/Maven/JavaFX/README.md
@@ -13,7 +13,7 @@ Clone this repository using the following command:
 
  ```bash
  git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
- cd JxBrowser-QuickStart/Gradle/JavaFX
+ cd JxBrowser-QuickStart/Maven/JavaFX
  ```
 
 ## Get License

--- a/Maven/JavaFX/pom.xml
+++ b/Maven/JavaFX/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>jxbrowser-javafx</artifactId>
             <version>${jxbrowser.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>17</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/Maven/JavaFX/pom.xml
+++ b/Maven/JavaFX/pom.xml
@@ -12,6 +12,7 @@
         <jxbrowser.version>8.1.0</jxbrowser.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloFX</exec.mainClass>
     </properties>
 
     <repositories>

--- a/Maven/JavaFX/src/main/java/HelloFX.java
+++ b/Maven/JavaFX/src/main/java/HelloFX.java
@@ -35,6 +35,10 @@ import javafx.stage.Stage;
  */
 public final class HelloFX extends Application {
 
+    public static void main(String[] args) {
+        launch(args); // Start the JavaFX application.
+    }
+
     @Override
     public void start(Stage primaryStage) {
         // Initialize Chromium.

--- a/Maven/SWT/README.md
+++ b/Maven/SWT/README.md
@@ -1,0 +1,32 @@
+# JxBrowser in SWT Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to embed an SWT `BrowserView` widget into an SWT desktop application to display web pages.
+
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
+ cd JxBrowser-QuickStart/Gradle/SWT
+ ```
+
+## Get License
+
+Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the SWT Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start an SWT desktop application with SWT `BrowserView` inside that displays https://html5test.teamdev.com as shown below:
+
+![SWT BrowserView](https://jxbrowser-support.teamdev.com/img/articles/swt-view.png)

--- a/Maven/SWT/README.md
+++ b/Maven/SWT/README.md
@@ -12,7 +12,7 @@ Clone this repository using the following command:
 
  ```bash
  git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
- cd JxBrowser-QuickStart/Gradle/SWT
+ cd JxBrowser-QuickStart/Maven/SWT
  ```
 
 ## Get License

--- a/Maven/SWT/pom.xml
+++ b/Maven/SWT/pom.xml
@@ -13,6 +13,7 @@
         <swt.version>4.3</swt.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloSWT</exec.mainClass>
     </properties>
 
     <repositories>

--- a/Maven/SWT/pom.xml
+++ b/Maven/SWT/pom.xml
@@ -43,7 +43,7 @@
 
         <dependency>
             <groupId>org.eclipse.swt</groupId>
-            <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
+            <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
             <version>${swt.version}</version>
         </dependency>
 

--- a/Maven/Swing/README.md
+++ b/Maven/Swing/README.md
@@ -1,0 +1,32 @@
+# JxBrowser in Swing Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to embed a Swing `BrowserView` widget into a Swing desktop application to display web pages.
+
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart
+ cd JxBrowser-QuickStart/Maven/Swing
+ ```
+
+## Get License
+
+Download a free 30-day evaluation license key by sending a request via the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the Swing Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start a Swing desktop application with Swing `BrowserView` inside that displays https://html5test.teamdev.com as shown below:
+
+![Swing BrowserView](https://jxbrowser-support.teamdev.com/img/articles/awt-swing-view.png)

--- a/Maven/Swing/pom.xml
+++ b/Maven/Swing/pom.xml
@@ -12,6 +12,7 @@
         <jxbrowser.version>8.1.0</jxbrowser.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloSwing</exec.mainClass>
     </properties>
 
     <repositories>


### PR DESCRIPTION
In this changeset, I have fixed some issues in README files in existing Gradle projects, and have added README files for Maven projects.

Issue: TeamDev-IP/JxBrowser/issues/4068